### PR TITLE
Fix BUILD_SHARED_LIBS=1 builds

### DIFF
--- a/lib/Tooling/CMakeLists.txt
+++ b/lib/Tooling/CMakeLists.txt
@@ -35,5 +35,6 @@ add_clang_library(clangTooling
   clangFrontend
   clangLex
   clangRewrite
+  clangSerialization
   clangToolingCore
   )

--- a/tools/arcmt-test/CMakeLists.txt
+++ b/tools/arcmt-test/CMakeLists.txt
@@ -12,4 +12,5 @@ target_link_libraries(arcmt-test
   clangBasic
   clangFrontend
   clangLex
+  clangSerialization
   )

--- a/tools/clang-check/CMakeLists.txt
+++ b/tools/clang-check/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(clang-check
   clangDriver
   clangFrontend
   clangRewriteFrontend
+  clangSerialization
   clangStaticAnalyzerFrontend
   clangTooling
   )

--- a/tools/clang-diff/CMakeLists.txt
+++ b/tools/clang-diff/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(clang-diff
   PRIVATE
   clangBasic
   clangFrontend
+  clangSerialization
   clangTooling
   clangToolingASTDiff
   )

--- a/tools/clang-func-mapping/CMakeLists.txt
+++ b/tools/clang-func-mapping/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(clang-func-mapping
   clangBasic
   clangCrossTU
   clangFrontend
+  clangSerialization
   clangTooling
   )
 

--- a/tools/clang-fuzzer/handle-cxx/CMakeLists.txt
+++ b/tools/clang-fuzzer/handle-cxx/CMakeLists.txt
@@ -8,5 +8,6 @@ add_clang_library(clangHandleCXX
   clangCodeGen
   clangFrontend
   clangLex
+  clangSerialization
   clangTooling
   )

--- a/tools/clang-import-test/CMakeLists.txt
+++ b/tools/clang-import-test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CLANG_IMPORT_TEST_LIB_DEPS
   clangFrontend
   clangLex
   clangParse
+  clangSerialization
   )
 
 target_link_libraries(clang-import-test

--- a/tools/clang-refactor/CMakeLists.txt
+++ b/tools/clang-refactor/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(clang-refactor
   clangFrontend
   clangLex
   clangRewrite
+  clangSerialization
   clangTooling
   clangToolingCore
   clangToolingRefactor

--- a/tools/clang-rename/CMakeLists.txt
+++ b/tools/clang-rename/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(clang-rename
   clangBasic
   clangFrontend
   clangRewrite
+  clangSerialization
   clangTooling
   clangToolingCore
   clangToolingRefactor

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(clang
   clangDriver
   clangFrontend
   clangFrontendTool
+  clangSerialization
   )
 
 if(WIN32 AND NOT CYGWIN)

--- a/tools/libclang/CMakeLists.txt
+++ b/tools/libclang/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LIBS
   clangIndex
   clangLex
   clangSema
+  clangSerialization
   clangTooling
 )
 

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -28,5 +28,6 @@ target_link_libraries(ASTTests
   clangASTMatchers
   clangBasic
   clangFrontend
+  clangSerialization
   clangTooling
   )

--- a/unittests/ASTMatchers/CMakeLists.txt
+++ b/unittests/ASTMatchers/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(ASTMatchersTests
   clangASTMatchers
   clangBasic
   clangFrontend
+  clangSerialization
   clangTooling
   )
 

--- a/unittests/ASTMatchers/Dynamic/CMakeLists.txt
+++ b/unittests/ASTMatchers/Dynamic/CMakeLists.txt
@@ -15,5 +15,6 @@ target_link_libraries(DynamicASTMatchersTests
   clangBasic
   clangDynamicASTMatchers
   clangFrontend
+  clangSerialization
   clangTooling
   )

--- a/unittests/Analysis/CMakeLists.txt
+++ b/unittests/Analysis/CMakeLists.txt
@@ -15,5 +15,6 @@ target_link_libraries(ClangAnalysisTests
   clangASTMatchers
   clangBasic
   clangFrontend
+  clangSerialization
   clangTooling
   )

--- a/unittests/CodeGen/CMakeLists.txt
+++ b/unittests/CodeGen/CMakeLists.txt
@@ -18,4 +18,5 @@ target_link_libraries(ClangCodeGenTests
   clangFrontend
   clangLex
   clangParse
+  clangSerialization
   )

--- a/unittests/CrossTU/CMakeLists.txt
+++ b/unittests/CrossTU/CMakeLists.txt
@@ -13,5 +13,6 @@ target_link_libraries(CrossTUTests
   clangBasic
   clangCrossTU
   clangFrontend
+  clangSerialization
   clangTooling
   )

--- a/unittests/Frontend/CMakeLists.txt
+++ b/unittests/Frontend/CMakeLists.txt
@@ -21,4 +21,5 @@ target_link_libraries(FrontendTests
   clangSema
   clangCodeGen
   clangFrontendTool
+  clangSerialization
   )

--- a/unittests/Index/CMakeLists.txt
+++ b/unittests/Index/CMakeLists.txt
@@ -14,5 +14,6 @@ target_link_libraries(IndexTests
   clangFrontend
   clangIndex
   clangLex
+  clangSerialization
   clangTooling
   )

--- a/unittests/Rename/CMakeLists.txt
+++ b/unittests/Rename/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(ClangRenameTests
   clangFormat
   clangFrontend
   clangRewrite
+  clangSerialization
   clangTooling
   clangToolingCore
   clangToolingRefactor

--- a/unittests/Sema/CMakeLists.txt
+++ b/unittests/Sema/CMakeLists.txt
@@ -14,5 +14,6 @@ target_link_libraries(SemaTests
   clangFrontend
   clangParse
   clangSema
+  clangSerialization
   clangTooling
   )

--- a/unittests/StaticAnalyzer/CMakeLists.txt
+++ b/unittests/StaticAnalyzer/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(StaticAnalysisTests
   clangBasic
   clangAnalysis
   clangFrontend
+  clangSerialization
   clangStaticAnalyzerCore
   clangStaticAnalyzerFrontend
   clangTooling

--- a/unittests/Tooling/CMakeLists.txt
+++ b/unittests/Tooling/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(ToolingTests
   clangFrontend
   clangLex
   clangRewrite
+  clangSerialization
   clangTooling
   clangToolingCore
   clangToolingInclusions


### PR DESCRIPTION
This PR contains the Clang upstream patches that fixed shared library builds in the aftermath of 6be5408 .